### PR TITLE
fix: error_handler.py had 'CANOE Compensation' as the project system,…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,6 @@ except Exception as e:
         url=api_url,
         token=error_token,
         fname="main.py",
-        projectsystem="CANOE Compensation",
+        projectsystem="new-ids-canoe-compensation",
         actualerrormsg=str(e)
     )


### PR DESCRIPTION
… when it ought to just be the name of the project system